### PR TITLE
Pull external IP from a safer source

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const MEMOIZE_OPTIONS = {
 }
 
 const getExternalIp = memoize(() => (
-  fetch('http://icanhazip.com').then(response => response.text())
+  fetch('http://ifconfig.co').then(response => response.text())
 ), MEMOIZE_OPTIONS)
 
 const getLocalIp = memoize(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const MEMOIZE_OPTIONS = {
 }
 
 const getExternalIp = memoize(() => (
-  fetch('http://ifconfig.co').then(response => response.text())
+  fetch('http://ifconfig.co/ip').then(response => response.text())
 ), MEMOIZE_OPTIONS)
 
 const getLocalIp = memoize(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const MEMOIZE_OPTIONS = {
 }
 
 const getExternalIp = memoize(() => (
-  fetch('http://ifconfig.co/ip').then(response => response.text())
+  fetch('https://ifconfig.co/ip').then(response => response.text())
 ), MEMOIZE_OPTIONS)
 
 const getLocalIp = memoize(() => {


### PR DESCRIPTION
The icanhazip.com domain is flagged as a listed malware source for corporate security checks.